### PR TITLE
When on Apple Silicon use arm64 binary from scode-shellcheck/shellcheck-binaries

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,6 +27,13 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+config_setting(
     name = "linux_x86_64",
     constraint_values = [
         "@platforms//os:linux",
@@ -46,6 +53,7 @@ alias(
     name = "shellcheck",
     actual = select(
         {
+            ":darwin_arm64": "@shellcheck_darwin_aarch64//:shellcheck",
             ":darwin_x86_64": "@shellcheck_darwin_amd64//:shellcheck",
             ":linux_aarch64": "@shellcheck_linux_arm64//:shellcheck",
             ":linux_x86_64": "@shellcheck_linux_amd64//:shellcheck",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "platforms", version = "0.0.7")
 deps = use_extension("//internal:extensions.bzl", "shellcheck_dependencies")
 use_repo(
     deps,
+    "shellcheck_darwin_aarch64",
     "shellcheck_darwin_amd64",
     "shellcheck_linux_amd64",
     "shellcheck_linux_arm64",

--- a/deps.bzl
+++ b/deps.bzl
@@ -30,6 +30,14 @@ def shellcheck_dependencies():
         "linux_arm64": "179c579ef3481317d130adebede74a34dbbc2df961a70916dd4039ebf0735fae",
     }
 
+    # pull darwin_aarch64 binaries from vscode-shellcheck/shellcheck-binaries
+    maybe(http_archive,
+        name = "shellcheck_darwin_aarch64",
+        build_file_content = 'exports_files(["shellcheck"])',
+        sha256 = "a75b912015aaa5b2a48698b63f3619783d90abda4d32a31362209315e6c1cdf6",
+        url = "https://github.com/vscode-shellcheck/shellcheck-binaries/releases/download/{version}/shellcheck-{version}.darwin.aarch64.tar.gz".format(version = version)
+    )
+
     for arch, sha256 in sha256.items():
         maybe(
             http_archive,


### PR DESCRIPTION
When on Apple Silicon use the arm64 binary from: https://github.com/vscode-shellcheck/shellcheck-binaries/releases/tag/v0.9.0

* Shellcheck proper does not yet publish this binary. 
* there is an issue open https://github.com/koalaman/shellcheck/issues/2714 but has not yet provided it's own arm64 build.
*  luckily [vscode-shellcheck/shellcheck-binaries](https://github.com/vscode-shellcheck/shellcheck-binaries/releases/tag/v0.9.0) does provide this binary